### PR TITLE
Add Cloudflare token UI and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.env

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -44,6 +44,36 @@
         button:hover {
             background-color: #0056b3;
         }
+        .token-box {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background-color: #f38020;
+            color: #fff;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            width: 220px;
+        }
+        .token-box input {
+            width: 100%;
+            margin-top: 5px;
+            border: none;
+            padding: 6px;
+            border-radius: 4px;
+        }
+        .token-box button {
+            width: 100%;
+            margin-top: 10px;
+            background-color: #fff;
+            color: #f38020;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .token-box button:hover {
+            background-color: #eee;
+        }
         #confirm {
             display: none;
             margin-top: 20px;
@@ -59,6 +89,15 @@
     </style>
 </head>
 <body>
+    <div class="token-box">
+        <div style="display:flex;align-items:center;gap:8px;">
+            <img src="https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/svg/cloudflare.svg" alt="Cloudflare" style="width:24px;height:24px;">
+            <span>Cloudflare Token</span>
+        </div>
+        <input type="password" id="token" placeholder="API Token" />
+        <button id="saveToken">Save</button>
+        <p id="tokenResult"></p>
+    </div>
     <div class="container">
         <h1>Register Service</h1>
         <label>Name of service:
@@ -84,6 +123,9 @@
         const confirmDiv = document.getElementById('confirm');
         const summary = document.getElementById('summary');
         const result = document.getElementById('result');
+        const saveTokenBtn = document.getElementById('saveToken');
+        const tokenInput = document.getElementById('token');
+        const tokenResult = document.getElementById('tokenResult');
 
         function collectData() {
             return {
@@ -115,6 +157,28 @@
                 }
             } catch (err) {
                 result.textContent = 'Submission failed';
+            }
+        });
+
+        saveTokenBtn.addEventListener('click', async () => {
+            const token = tokenInput.value.trim();
+            if (!token) {
+                tokenResult.textContent = 'Token cannot be empty';
+                return;
+            }
+            try {
+                const resp = await fetch('/token', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ token })
+                });
+                if (resp.ok) {
+                    tokenResult.textContent = 'Token saved';
+                } else {
+                    tokenResult.textContent = 'Failed to save token';
+                }
+            } catch (e) {
+                tokenResult.textContent = 'Failed to save token';
             }
         });
     </script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.1.2        
 Werkzeug<2.1.0    
-requests==2.31.0    
+requests==2.31.0
+python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- allow persisting the Cloudflare API token via `.env`
- load `.env` from the Flask app on startup
- update GUI with a Cloudflare token box and save button
- handle `/token` POST endpoint for saving
- add `python-dotenv` dependency and ignore `.env`

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685375db75ec83248a7d56bf6e65907c